### PR TITLE
add getModel method to allow overriding the Model at runtime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,15 +27,19 @@ class Service {
     return Proto.extend(obj, this);
   }
 
+  getModel (params) {
+    return this.Model;
+  }
+
   _find (params, count, getFilter = filterQuery) {
     // Start with finding all, and limit when necessary.
     let { filters, query } = getFilter(params.query || {});
 
-    let q = this.Model.find(query);
+    let q = this.getModel(params).find(query);
 
     // $select uses a specific find syntax, so it has to come first.
     if (filters.$select) {
-      q = this.Model.find(query, getSelect(filters.$select));
+      q = this.getModel(params).find(query, getSelect(filters.$select));
     }
 
     // Handle $sort
@@ -76,7 +80,7 @@ class Service {
     }
 
     if (count) {
-      return nfcall(this.Model, 'count', query).then(runQuery);
+      return nfcall(this.getModel(params), 'count', query).then(runQuery);
     }
 
     return runQuery();
@@ -95,7 +99,7 @@ class Service {
   }
 
   _get (id, params) {
-    return nfcall(this.Model, 'findOne', { [this.id]: id })
+    return nfcall(this.getModel(params), 'findOne', { [this.id]: id })
       .then(doc => {
         if (!doc) {
           throw new errors.NotFound(`No record found for id '${id}'`);
@@ -130,7 +134,7 @@ class Service {
     };
     const data = Array.isArray(raw) ? raw.map(addId) : addId(raw);
 
-    return nfcall(this.Model, 'insert', data)
+    return nfcall(this.getModel(params), 'insert', data)
       .then(select(params, this.id));
   }
 
@@ -164,7 +168,7 @@ class Service {
           }
         });
 
-        return nfcall(this.Model, 'update', query, updateData, options)
+        return nfcall(this.getModel(params), 'update', query, updateData, options)
           .then(() => this._findOrGet(id, findParams));
       })
       .then(select(params, this.id));
@@ -182,7 +186,7 @@ class Service {
       entry[this.id] = id;
     }
 
-    return nfcall(this.Model, 'update', query, entry, options)
+    return nfcall(this.getModel(params), 'update', query, entry, options)
       .then(() => this._findOrGet(id))
       .then(select(params, this.id));
   }
@@ -191,7 +195,7 @@ class Service {
     const { query, options } = multiOptions(id, this.id, params);
 
     return this._findOrGet(id, params).then(items =>
-      nfcall(this.Model, 'remove', query, options)
+      nfcall(this.getModel(params), 'remove', query, options)
         .then(() => items)
     ).then(select(params, this.id));
   }


### PR DESCRIPTION
[feathers-sequelize implements this in the same way:](https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/master/lib/index.js#L26-L28) 

I needed to transparently switch models based on the user's scope and this seemed like an easy way.