### PR TITLE
NeDB forks comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install --save nedb feathers-nedb
 Returns a new service instance initialized with the given options. `Model` has to be an NeDB database instance.
 
 ```js
-const NeDB = require('nedb');
+const NeDB = require('nedb'); // seald-io/nedb also works
 const service = require('feathers-nedb');
 
 // Create a NeDB instance

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install --save nedb feathers-nedb
 Returns a new service instance initialized with the given options. `Model` has to be an NeDB database instance.
 
 ```js
-const NeDB = require('nedb'); // seald-io/nedb also works
+const NeDB = require('nedb'); // @seald-io/nedb also works
 const service = require('feathers-nedb');
 
 // Create a NeDB instance


### PR DESCRIPTION
### Summary

https://codesandbox.io/s/feathers-crow-seald-io-nedb-4v7c4?file=/src/models/users.model.ts

I've verified [@seald-io/nedb](https://www.npmjs.com/package/@seald-io/nedb), works. It's the leading fork, specially after nedb-promises switched to it as it's backend.

nedb-promises does not work and returns this error:

```
[INFO] 10:18:22 ts-node-dev ver. 1.1.8 (using ts-node ver. 9.1.1, typescript ver. 4.4.3)
Compilation error in /sandbox/src/models/users.model.ts
[ERROR] 10:18:31 ⨯ Unable to compile TypeScript:
src/models/users.model.ts:6:45 - error TS2315: Type 'Datastore' is not generic.

6 export default function (app: Application): NeDB<any> {
```
